### PR TITLE
Discover Tchap platform

### DIFF
--- a/Riot.xcodeproj/project.pbxproj
+++ b/Riot.xcodeproj/project.pbxproj
@@ -296,6 +296,10 @@
 		0250C5CA2122E63900034691 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0250C5C62122E63900034691 /* main.m */; };
 		0250C5CB2122E63900034691 /* empty.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0250C5C82122E63900034691 /* empty.mm */; };
 		0250C5CE212314B300034691 /* Tchap-Defaults.plist in Resources */ = {isa = PBXBuildFile; fileRef = 0250C5CD212314B300034691 /* Tchap-Defaults.plist */; };
+		02BEE15C2125D11000098505 /* ThirdPartyIDPlatformInfoResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BEE15A2125D11000098505 /* ThirdPartyIDPlatformInfoResolver.swift */; };
+		02BEE15D2125D11000098505 /* ThirdPartyIDPlatformInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BEE15B2125D11000098505 /* ThirdPartyIDPlatformInfo.swift */; };
+		02BEE15F2125EB5900098505 /* ThirdPartyIDPlatformInfoType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BEE15E2125EB5900098505 /* ThirdPartyIDPlatformInfoType.swift */; };
+		02BEE1612125EC2200098505 /* IdentityServersURLGetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BEE1602125EC2200098505 /* IdentityServersURLGetter.swift */; };
 		24CBEC591F0EAD310093EABB /* RiotShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 24CBEC4E1F0EAD310093EABB /* RiotShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		24EEE5A21F23A8B400B3C705 /* MXRoom+Riot.m in Sources */ = {isa = PBXBuildFile; fileRef = F083BBE81E7009EC00A9B29C /* MXRoom+Riot.m */; };
 		24EEE5A31F23A8C300B3C705 /* AvatarGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = F083BC111E7009EC00A9B29C /* AvatarGenerator.m */; };
@@ -696,6 +700,10 @@
 		0250C5C72122E63900034691 /* Tchap.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Tchap.entitlements; sourceTree = "<group>"; };
 		0250C5C82122E63900034691 /* empty.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = empty.mm; sourceTree = "<group>"; };
 		0250C5CD212314B300034691 /* Tchap-Defaults.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Tchap-Defaults.plist"; sourceTree = "<group>"; };
+		02BEE15A2125D11000098505 /* ThirdPartyIDPlatformInfoResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThirdPartyIDPlatformInfoResolver.swift; sourceTree = "<group>"; };
+		02BEE15B2125D11000098505 /* ThirdPartyIDPlatformInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThirdPartyIDPlatformInfo.swift; sourceTree = "<group>"; };
+		02BEE15E2125EB5900098505 /* ThirdPartyIDPlatformInfoType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdPartyIDPlatformInfoType.swift; sourceTree = "<group>"; };
+		02BEE1602125EC2200098505 /* IdentityServersURLGetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityServersURLGetter.swift; sourceTree = "<group>"; };
 		0598CA8AB2933381369BED6C /* Pods-RiotPods-Tchap.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RiotPods-Tchap.release.xcconfig"; path = "Pods/Target Support Files/Pods-RiotPods-Tchap/Pods-RiotPods-Tchap.release.xcconfig"; sourceTree = "<group>"; };
 		12AA0005C8B3D8D8162584C5 /* Pods-RiotShareExtension.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RiotShareExtension.debug.xcconfig"; path = "Pods/Target Support Files/Pods-RiotShareExtension/Pods-RiotShareExtension.debug.xcconfig"; sourceTree = "<group>"; };
 		22D76C11C202B6BC5917A049 /* Pods-RiotPods-RiotShareExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RiotPods-RiotShareExtension.release.xcconfig"; path = "Pods/Target Support Files/Pods-RiotPods-RiotShareExtension/Pods-RiotPods-RiotShareExtension.release.xcconfig"; sourceTree = "<group>"; };
@@ -1294,6 +1302,7 @@
 		0250C5C12122BBA600034691 /* Tchap */ = {
 			isa = PBXGroup;
 			children = (
+				0250C5CF21233DEE00034691 /* Managers */,
 				0250C5CC2123146A00034691 /* Assets */,
 				0250C5C22122BBD200034691 /* SupportingFiles */,
 			);
@@ -1318,6 +1327,25 @@
 				0250C5CD212314B300034691 /* Tchap-Defaults.plist */,
 			);
 			path = Assets;
+			sourceTree = "<group>";
+		};
+		0250C5CF21233DEE00034691 /* Managers */ = {
+			isa = PBXGroup;
+			children = (
+				02BEE1592125D11000098505 /* ThirdPartyIDPlatformInfoResolver */,
+			);
+			path = Managers;
+			sourceTree = "<group>";
+		};
+		02BEE1592125D11000098505 /* ThirdPartyIDPlatformInfoResolver */ = {
+			isa = PBXGroup;
+			children = (
+				02BEE15A2125D11000098505 /* ThirdPartyIDPlatformInfoResolver.swift */,
+				02BEE15B2125D11000098505 /* ThirdPartyIDPlatformInfo.swift */,
+				02BEE15E2125EB5900098505 /* ThirdPartyIDPlatformInfoType.swift */,
+				02BEE1602125EC2200098505 /* IdentityServersURLGetter.swift */,
+			);
+			path = ThirdPartyIDPlatformInfoResolver;
 			sourceTree = "<group>";
 		};
 		24CBEC4F1F0EAD310093EABB /* RiotShareExtension */ = {
@@ -3605,6 +3633,7 @@
 				0250C4D02122B68000034691 /* RoomDataSource.m in Sources */,
 				0250C4D12122B68000034691 /* RoomIncomingTextMsgWithoutSenderNameBubbleCell.m in Sources */,
 				0250C4D22122B68000034691 /* LanguagePickerViewController.m in Sources */,
+				02BEE15F2125EB5900098505 /* ThirdPartyIDPlatformInfoType.swift in Sources */,
 				0250C4D32122B68000034691 /* RoomIncomingTextMsgWithoutSenderInfoBubbleCell.m in Sources */,
 				0250C4D42122B68000034691 /* RoomIncomingEncryptedTextMsgBubbleCell.m in Sources */,
 				0250C4D52122B68000034691 /* MasterTabBarController.m in Sources */,
@@ -3645,6 +3674,7 @@
 				0250C4F82122B68000034691 /* RoomIdOrAliasTableViewCell.m in Sources */,
 				0250C4F92122B68000034691 /* RoomPreviewData.m in Sources */,
 				0250C4FA2122B68000034691 /* EventDetailsView.m in Sources */,
+				02BEE15C2125D11000098505 /* ThirdPartyIDPlatformInfoResolver.swift in Sources */,
 				0250C4FB2122B68000034691 /* IncomingCallView.m in Sources */,
 				0250C4FC2122B68000034691 /* GroupTableViewCell.m in Sources */,
 				0250C4FD2122B68000034691 /* GroupHomeViewController.m in Sources */,
@@ -3659,6 +3689,7 @@
 				0250C5062122B68000034691 /* AuthInputsView.m in Sources */,
 				0250C5072122B68000034691 /* InviteRecentTableViewCell.m in Sources */,
 				0250C5082122B68000034691 /* ContactDetailsViewController.m in Sources */,
+				02BEE15D2125D11000098505 /* ThirdPartyIDPlatformInfo.swift in Sources */,
 				0250C5092122B68000034691 /* OnBoardingManager.swift in Sources */,
 				0250C50A2122B68000034691 /* GroupDetailsViewController.m in Sources */,
 				0250C50B2122B68000034691 /* RoomKeyRequestViewController.m in Sources */,
@@ -3685,6 +3716,7 @@
 				0250C5202122B68000034691 /* MatrixSDK+Swift.m in Sources */,
 				0250C5212122B68000034691 /* RoomMembershipBubbleCell.m in Sources */,
 				0250C5222122B68000034691 /* DisabledRoomInputToolbarView.m in Sources */,
+				02BEE1612125EC2200098505 /* IdentityServersURLGetter.swift in Sources */,
 				0250C5232122B68000034691 /* GroupTableViewCellWithSwitch.m in Sources */,
 				0250C5242122B68000034691 /* MessagesSearchResultTextMsgBubbleCell.m in Sources */,
 				0250C5252122B68000034691 /* RoomBubbleCellData.m in Sources */,

--- a/Tchap/Assets/Tchap-Defaults.plist
+++ b/Tchap/Assets/Tchap-Defaults.plist
@@ -2,6 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>serverUrlPrefix</key>
+	<string>https://matrix.</string>
+	<key>preferredIdentityServerNames</key>
+	<array>
+		<string>i.tchap.gouv.fr</string>
+		<string>a.tchap.gouv.fr</string>
+	</array>
+	<key>otherIdentityServerNames</key>
+	<array/>
 	<key>pinRoomsWithMissedNotif</key>
 	<true/>
 	<key>pinRoomsWithUnread</key>

--- a/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/IdentityServersURLGetter.swift
+++ b/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/IdentityServersURLGetter.swift
@@ -18,18 +18,20 @@ import Foundation
 
 
 /// `IdentityServersURLGetter` is used to retrieved all the known identity server urls.
-final public class IdentityServersURLGetter {
+final class IdentityServersURLGetter {
     
     // MARK: - Public
     
     // The available identity servers
-    public var identityServerUrls = [String]()
+    let identityServerUrls: [String]
     
     /// Prepare the list of the known ISes
     ///
     /// - Parameters:
     ///   - currentIdentityServerURL: the current identity server if any.
-    public init(currentIdentityServerURL: String?) {
+    init(currentIdentityServerURL: String?) {
+        var identityServerUrls: [String] = []
+        
         // Consider first the current identity server if any.
         if let currentIdentityServerURL = currentIdentityServerURL {
             identityServerUrls.append(currentIdentityServerURL)
@@ -54,5 +56,7 @@ final public class IdentityServersURLGetter {
                 }
             }
         }
+        
+        self.identityServerUrls = identityServerUrls
     }
 }

--- a/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/IdentityServersURLGetter.swift
+++ b/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/IdentityServersURLGetter.swift
@@ -18,7 +18,7 @@ import Foundation
 
 
 /// `IdentityServersURLGetter` is used to retrieved all the known identity server urls.
-final public class IdentityServersURLGetter: NSObject {
+final public class IdentityServersURLGetter {
     
     // MARK: - Public
     
@@ -54,7 +54,5 @@ final public class IdentityServersURLGetter: NSObject {
                 }
             }
         }
-        
-        super.init()
     }
 }

--- a/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/IdentityServersURLGetter.swift
+++ b/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/IdentityServersURLGetter.swift
@@ -1,0 +1,60 @@
+/*
+ Copyright 2018 New Vector Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+
+/// `IdentityServersURLGetter` is used to retrieved all the known identity server urls.
+final public class IdentityServersURLGetter: NSObject {
+    
+    // MARK: - Public
+    
+    // The available identity servers
+    public var identityServerUrls = [String]()
+    
+    /// Prepare the list of the known ISes
+    ///
+    /// - Parameters:
+    ///   - currentIdentityServerURL: the current identity server if any.
+    public init(currentIdentityServerURL: String?) {
+        // Consider first the current identity server if any.
+        if let currentIdentityServerURL = currentIdentityServerURL {
+            identityServerUrls.append(currentIdentityServerURL)
+        }
+        
+        if let identityServerPrefixURL = UserDefaults.standard.string(forKey: "serverUrlPrefix") {
+            if var preferredKnownHosts = UserDefaults.standard.stringArray(forKey: "preferredIdentityServerNames") {
+                // Add randomly the preferred known ISes
+                while preferredKnownHosts.count > 0 {
+                    let index = Int(arc4random_uniform(UInt32(preferredKnownHosts.count)))
+                    identityServerUrls.append("\(identityServerPrefixURL)\(preferredKnownHosts[index])")
+                    preferredKnownHosts.remove(at: index)
+                }
+            }
+            
+            if var otherKnownHosts = UserDefaults.standard.stringArray(forKey: "otherIdentityServerNames") {
+                // Add randomly the other known ISes
+                while otherKnownHosts.count > 0 {
+                    let index = Int(arc4random_uniform(UInt32(otherKnownHosts.count)))
+                    identityServerUrls.append("\(identityServerPrefixURL)\(otherKnownHosts[index])")
+                    otherKnownHosts.remove(at: index)
+                }
+            }
+        }
+        
+        super.init()
+    }
+}

--- a/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/ThirdPartyIDPlatformInfo.swift
+++ b/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/ThirdPartyIDPlatformInfo.swift
@@ -1,0 +1,25 @@
+/*
+ Copyright 2018 New Vector Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+/// Structure use to return the platform information related to a third-party identifier.
+public struct ThirdPartyIDPlatformInfo: ThirdPartyIDPlatformInfoType {
+    // The hostname of the platform.
+    public let hostname: String
+    // Tell whether the given 3pid has been invited to the platform or not.
+    public var isInvited: Bool
+}

--- a/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/ThirdPartyIDPlatformInfo.swift
+++ b/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/ThirdPartyIDPlatformInfo.swift
@@ -17,9 +17,9 @@
 import Foundation
 
 /// Structure use to return the platform information related to a third-party identifier.
-public struct ThirdPartyIDPlatformInfo: ThirdPartyIDPlatformInfoType {
+struct ThirdPartyIDPlatformInfo: ThirdPartyIDPlatformInfoType {
     // The hostname of the platform.
-    public let hostname: String
+    let hostname: String
     // Tell whether the given 3pid has been invited to the platform or not.
-    public var isInvited: Bool
+    let isInvited: Bool
 }

--- a/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/ThirdPartyIDPlatformInfoResolver.swift
+++ b/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/ThirdPartyIDPlatformInfoResolver.swift
@@ -1,0 +1,93 @@
+/*
+ Copyright 2018 New Vector Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+/// List the different result cases
+public enum ResolveResult {
+    case authorizedThirdPartyID(info: ThirdPartyIDPlatformInfoType)
+    case unauthorizedThirdPartyID
+}
+
+/// `ThirdPartyIDPlatformInfoResolver` is used to check whether a third-party identifier (for example: an email address) is authorized in Tchap.
+/// It is used to retrieve the information of the platform associated to an authorized 3pid.
+final public class ThirdPartyIDPlatformInfoResolver: NSObject {
+    
+    // The list of the known ISes in order to run over the list until to get an answer.
+    private let identityServerUrls: [String]
+    private var currentIndex = 0;
+    
+    // MARK: - Public
+    
+    /// - Parameters:
+    ///   - identityServerUrls: the list of the known ISes in order to run over the list until to get an answer.
+    public init(identityServerUrls: [String]) {
+        self.identityServerUrls = identityServerUrls
+        
+        super.init()
+    }
+    
+    /// Check whether a third-party identifier is authorized or not.
+    /// The platform information for this identifier are available only when it is authorized.
+    ///
+    /// - Parameters:
+    ///   - address: The third party identifier (email address, msisdn,...).
+    ///   - medium: the type of the third-party id (see kMX3PIDMediumEmail, kMX3PIDMediumMSISDN).
+    ///   - success: A block object called when the operation succeeds.
+    ///   - failure: A block object called when the operation fails.
+    public func resolvePlatformInformationFor(address: String, medium: String, success: ((ResolveResult) -> Void)?, failure: ((Error?) -> Void)?) {
+        guard currentIndex < identityServerUrls.count else {
+            failure?(nil)
+            return
+        }
+        
+        let identityServer = identityServerUrls[currentIndex]
+        
+        guard let identityHttpClient = MXHTTPClient(baseURL: "\(identityServer)\(kMXIdentityAPIPrefixPath)", andOnUnrecognizedCertificateBlock: nil) else {
+                failure?(nil)
+                return
+        }
+        
+        identityHttpClient.request(withMethod: "GET", path: "info", parameters: ["address": address, "medium": medium], success: { (response: [AnyHashable: Any]?) in
+            guard let response = response else {
+                success?(.unauthorizedThirdPartyID)
+                return
+            }
+            
+            NSLog("[ThirdPartyIDPlatformInfoResolver] info resquest on \(identityServer) succeeded")
+            
+            let isInvited = response["invited"] as? Bool ?? false
+            
+            if let hostname = response["hs"] as? String {
+                let info = ThirdPartyIDPlatformInfo(hostname: hostname, isInvited: isInvited);
+                success?(.authorizedThirdPartyID(info: info));
+            } else {
+                success?(.unauthorizedThirdPartyID);
+            }
+        }, failure: { (error: Error?) in
+            NSLog("[ThirdPartyIDPlatformInfoResolver] info resquest on \(identityServer) failed")
+            
+            // Try another identity server
+            self.currentIndex += 1
+            if self.currentIndex < self.identityServerUrls.count {
+                // Try on anothezr server
+                self.resolvePlatformInformationFor(address: address, medium: medium, success: success, failure: failure)
+            } else {
+                failure?(error)
+            }
+        })
+    }
+}

--- a/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/ThirdPartyIDPlatformInfoType.swift
+++ b/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/ThirdPartyIDPlatformInfoType.swift
@@ -1,0 +1,26 @@
+/*
+ Copyright 2018 New Vector Ltd
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+import Foundation
+
+
+/// Protocol use to handle the platform information related to a third-party identifier.
+public protocol ThirdPartyIDPlatformInfoType {
+    // The hostname of the platform.
+    var hostname: String {get}
+    // Tell whether the given 3pid has been invited to the platform or not.
+    var isInvited: Bool {get}
+}

--- a/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/ThirdPartyIDPlatformInfoType.swift
+++ b/Tchap/Managers/ThirdPartyIDPlatformInfoResolver/ThirdPartyIDPlatformInfoType.swift
@@ -18,7 +18,7 @@ import Foundation
 
 
 /// Protocol use to handle the platform information related to a third-party identifier.
-public protocol ThirdPartyIDPlatformInfoType {
+protocol ThirdPartyIDPlatformInfoType {
     // The hostname of the platform.
     var hostname: String {get}
     // Tell whether the given 3pid has been invited to the platform or not.


### PR DESCRIPTION
Add a ThirdPartyIDPlatformInfoResolver used to check whether a third-party identifier (for example: an email address) is authorized in Tchap or not.

#22