### PR TITLE
A public room may become private

### DIFF
--- a/Tchap/Assets/Localizations/fr.lproj/Tchap.strings
+++ b/Tchap/Assets/Localizations/fr.lproj/Tchap.strings
@@ -98,6 +98,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 // MARK: Room Settings
 "room_settings_tab_title" = "Paramètres";
+"room_settings_remove_from_rooms_directory" = "Retirer ce salon de la liste des salons publics";
+"room_settings_remove_from_rooms_directory_prompt" = "Cette action est irréversible.\nVoulez-vous vraiment retirer ce salon des salons publics ?";
 
 ////////////////////////////////////////////////////////////////////////////////
 // MARK: Public rooms

--- a/Tchap/Constants/Strings.swift
+++ b/Tchap/Constants/Strings.swift
@@ -119,6 +119,10 @@ internal enum TchapL10n {
   internal static let roomMemberDetailsActionChat = TchapL10n.tr("Tchap", "room_member_details_action_chat")
   /// Membres
   internal static let roomMembersTabTitle = TchapL10n.tr("Tchap", "room_members_tab_title")
+  /// Retirer ce salon de la liste des salons publics
+  internal static let roomSettingsRemoveFromRoomsDirectory = TchapL10n.tr("Tchap", "room_settings_remove_from_rooms_directory")
+  /// Cette action est irréversible.\nVoulez-vous vraiment retirer ce salon des salons publics ?
+  internal static let roomSettingsRemoveFromRoomsDirectoryPrompt = TchapL10n.tr("Tchap", "room_settings_remove_from_rooms_directory_prompt")
   /// Paramètres
   internal static let roomSettingsTabTitle = TchapL10n.tr("Tchap", "room_settings_tab_title")
   /// Aucun résultat

--- a/Tchap/Modules/Room/Settings/RoomSettingsViewController.m
+++ b/Tchap/Modules/Room/Settings/RoomSettingsViewController.m
@@ -1531,12 +1531,10 @@ NSString *const kRoomSettingsBannedUserCellViewIdentifier = @"kRoomSettingsBanne
             failure(error);
             
         }];
-        return;
     }
-    
-    // Turn on the encryption if it is not already enabled
-    if (!self->mxRoom.summary.isEncrypted)
+    else if (!self->mxRoom.summary.isEncrypted)
     {
+        // Turn on the encryption if it is not already enabled
         NSLog(@"[RoomSettingsViewController] Enable encrytion");
         self->pendingOperation = [self->mxRoom enableEncryptionWithAlgorithm:kMXCryptoMegolmAlgorithm success:^{
             
@@ -1554,18 +1552,19 @@ NSString *const kRoomSettingsBannedUserCellViewIdentifier = @"kRoomSettingsBanne
             failure(error);
             
         }];
-        return;
     }
-    
-    // Remove the room from the rooms directory
-    self->pendingOperation = [self->mxRoom setDirectoryVisibility:kMXRoomDirectoryVisibilityPrivate success:^{
-        
-        MXStrongifyAndReturnIfNil(self);
-        self->pendingOperation = nil;
-        [self stopActivityIndicator];
-        [self refreshRoomSettings];
-        
-    } failure:failure];
+    else
+    {
+        // Remove the room from the rooms directory
+        self->pendingOperation = [self->mxRoom setDirectoryVisibility:kMXRoomDirectoryVisibilityPrivate success:^{
+            
+            MXStrongifyAndReturnIfNil(self);
+            self->pendingOperation = nil;
+            [self stopActivityIndicator];
+            [self refreshRoomSettings];
+            
+        } failure:failure];
+    }
 }
 
 @end


### PR DESCRIPTION
- The encryption is then enabled by default
- The new members can access only on invite

We improve here the UI. We prompt the user as soon as he switches the toggle button. The action is not delayed to the "Save" action. We remove the room from the publics as soon as the user decides the change.