### PR TITLE
Bug Fix: SettingsViewController instances are not deallocated

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -133,10 +133,10 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   MatrixKit:
-    :commit: 064ea5ab77e361f3b33b2f35b7a1c7fb205ba325
+    :commit: 99969ff98b7029c2c0fe8f1edcf9a5f23501fdb1
     :git: https://github.com/matrix-org/matrix-ios-kit.git
   MatrixSDK:
-    :commit: e95479104398e67861491e2526736d74ac96826a
+    :commit: 8a61f29211c34f78589a6a41c6a2fcb6c0d07c84
     :git: https://github.com/matrix-org/matrix-ios-sdk.git
   PiwikTracker:
     :commit: dfb048f25f4eefbe13ff7515c3c1c2cad5d94491

--- a/Riot/Modules/Common/WebViewController/WebViewViewController.m
+++ b/Riot/Modules/Common/WebViewController/WebViewViewController.m
@@ -22,12 +22,11 @@
 #import "GeneratedInterface-Swift.h"
 
 @interface WebViewViewController () <Stylable>
-{
-    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
-    id kRiotDesignValuesDidChangeThemeNotificationObserver;
-}
 
 @property (nonatomic, strong) id<Style> currentStyle;
+
+// Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+@property (nonatomic, weak) id kRiotDesignValuesDidChangeThemeNotificationObserver;
 
 @end
 
@@ -57,8 +56,10 @@
     [super viewDidLoad];
     
     // Observe user interface theme change.
-    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+    MXWeakify(self);
+    _kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
         
+        MXStrongifyAndReturnIfNil(self);
         [self userInterfaceThemeDidChange];
         
     }];
@@ -99,15 +100,12 @@
     return self.currentStyle.statusBarStyle;
 }
 
-- (void)destroy
+- (void)dealloc
 {
-    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    if (_kRiotDesignValuesDidChangeThemeNotificationObserver)
     {
-        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
-        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+        [[NSNotificationCenter defaultCenter] removeObserver:_kRiotDesignValuesDidChangeThemeNotificationObserver];
     }
-    
-    [super destroy];
 }
 
 @end

--- a/Riot/Modules/MediaPicker/Library/MediaAlbumContentViewController.h
+++ b/Riot/Modules/MediaPicker/Library/MediaAlbumContentViewController.h
@@ -69,7 +69,7 @@
 /**
  The delegate for the view controller.
  */
-@property (nonatomic) id<MediaAlbumContentViewControllerDelegate> delegate;
+@property (nonatomic, weak) id<MediaAlbumContentViewControllerDelegate> delegate;
 
 /**
  The array of the media types listed by the view controller (default value is an array containing kUTTypeImage).

--- a/Riot/Modules/MediaPicker/MediaPickerViewController.m
+++ b/Riot/Modules/MediaPicker/MediaPickerViewController.m
@@ -302,17 +302,13 @@ static void *RecordingContext = &RecordingContext;
     cameraPreviewLayer.hidden = YES;
     [self.cameraActivityIndicator startAnimating];
     
-    MXWeakify(self);
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(coordinator.transitionDuration * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         
-        MXStrongifyAndReturnIfNil(self);
         [self handleScreenOrientation];
         
         // Show camera preview with delay to hide awful animation
-        MXWeakify(self);
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             
-            MXStrongifyAndReturnIfNil(self);
             [self.cameraActivityIndicator stopAnimating];
             self->cameraPreviewLayer.hidden = NO;
             
@@ -330,16 +326,15 @@ static void *RecordingContext = &RecordingContext;
             showPopUpInViewController:self
                     completionHandler:^(BOOL granted) {
                         
+                        // Check whether the picker has not been removed before reloading the user albums.
                         MXStrongifyAndReturnIfNil(self);
                         if (granted)
                         {
                             // Load recent captures if this is not already done
                             if (!self->recentCaptures.count)
                             {
-                                MXWeakify(self);
                                 dispatch_async(dispatch_get_main_queue(), ^{
                                     
-                                    MXStrongifyAndReturnIfNil(self);
                                     [self reloadRecentCapturesCollection];
                                     [self reloadUserLibraryAlbums];
                                     
@@ -583,10 +578,8 @@ static void *RecordingContext = &RecordingContext;
         return;
     }
     
-    MXWeakify(self);
     dispatch_async(userAlbumsQueue, ^{
         
-        MXStrongifyAndReturnIfNil(self);
         // List user albums which are not empty
         PHFetchResult *albums = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeAlbumRegular options:nil];
         
@@ -644,10 +637,8 @@ static void *RecordingContext = &RecordingContext;
             [updatedUserAlbums insertObject:cameraRollAlbum atIndex:0];
         }
         
-        MXWeakify(self);
         dispatch_async(dispatch_get_main_queue(), ^{
             
-            MXStrongifyAndReturnIfNil(self);
             self->userAlbums = updatedUserAlbums;
             if (self->userAlbums.count)
             {
@@ -823,10 +814,8 @@ static void *RecordingContext = &RecordingContext;
         [[PHImageManager defaultManager] requestAVAssetForVideo:asset options:options resultHandler:^(AVAsset * _Nullable asset, AVAudioMix * _Nullable audioMix, NSDictionary * _Nullable info) {
             
             MXStrongifyAndReturnIfNil(self);
-            MXWeakify(self);
             dispatch_async(dispatch_get_main_queue(), ^{
                 
-                MXStrongifyAndReturnIfNil(self);
                 if ([topVC respondsToSelector:@selector(stopActivityIndicator)])
                 {
                     [topVC stopActivityIndicator];
@@ -1102,10 +1091,8 @@ static void *RecordingContext = &RecordingContext;
     
     [self.cameraActivityIndicator startAnimating];
     
-    MXWeakify(self);
     dispatch_async(cameraQueue, ^{
         
-        MXStrongifyAndReturnIfNil(self);
         // Get the Camera Device
         AVCaptureDevice *frontCamera = nil;
         AVCaptureDevice *backCamera = nil;
@@ -1191,9 +1178,7 @@ static void *RecordingContext = &RecordingContext;
             }
         }
         
-        MXWeakify(self);
         dispatch_async(dispatch_get_main_queue(), ^{
-            MXStrongifyAndReturnIfNil(self);
             self.cameraSwitchButton.hidden = (!frontCamera || !backCamera);
         });
         
@@ -1271,9 +1256,7 @@ static void *RecordingContext = &RecordingContext;
         }
         else
         {
-            MXWeakify(self);
             dispatch_async(dispatch_get_main_queue(), ^{
-                MXStrongifyAndReturnIfNil(self);
                 [self.cameraActivityIndicator stopAnimating];
             });
         }
@@ -1338,10 +1321,8 @@ static void *RecordingContext = &RecordingContext;
     NSError *error = [[note userInfo] objectForKey:AVCaptureSessionErrorKey];
     NSLog(@"[MediaPickerVC] AV Session Error: %@", error);
     
-    MXWeakify(self);
     dispatch_async(dispatch_get_main_queue(), ^{
         
-        MXStrongifyAndReturnIfNil(self);
         [self tearDownAVCapture];
         // Retry
         [self performSelector:@selector(setupAVCapture) withObject:nil afterDelay:1.0];
@@ -1352,10 +1333,8 @@ static void *RecordingContext = &RecordingContext;
 - (void)AVCaptureSessionDidStartRunning:(NSNotification*)note
 {
     // Show camera preview with delay to hide camera settlement
-    MXWeakify(self);
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.6 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         
-        MXStrongifyAndReturnIfNil(self);
         [self.cameraActivityIndicator stopAnimating];
         self->cameraPreviewLayer.hidden = NO;
         
@@ -1371,10 +1350,8 @@ static void *RecordingContext = &RecordingContext;
 {
     if (frontCameraInput && backCameraInput)
     {
-        MXWeakify(self);
         dispatch_async(dispatch_get_main_queue(), ^{
             
-            MXStrongifyAndReturnIfNil(self);
             if (!self->canToggleCamera)
             {
                 return;
@@ -1394,10 +1371,8 @@ static void *RecordingContext = &RecordingContext;
                 oldInput = self->backCameraInput;
             }
             
-            MXWeakify(self);
             dispatch_async(self->cameraQueue, ^{
                 
-                MXStrongifyAndReturnIfNil(self);
                 [self->captureSession beginConfiguration];
                 [self->captureSession removeInput:oldInput];
                 if ([self->captureSession canAddInput:newInput]) {
@@ -1406,10 +1381,8 @@ static void *RecordingContext = &RecordingContext;
                 }
                 [self->captureSession commitConfiguration];
                 
-                MXWeakify(self);
                 dispatch_async(dispatch_get_main_queue(), ^{
                     
-                    MXStrongifyAndReturnIfNil(self);
                     [self.cameraActivityIndicator stopAnimating];
                     self->cameraPreviewLayer.hidden = NO;
                     self->canToggleCamera = YES;
@@ -1426,10 +1399,8 @@ static void *RecordingContext = &RecordingContext;
 {
     self.cameraCaptureButton.enabled = NO;
     
-    MXWeakify(self);
     dispatch_async(cameraQueue, ^{
         
-        MXStrongifyAndReturnIfNil(self);
         if (![self->movieFileOutput isRecording])
         {
             self->lockInterfaceRotation = YES;
@@ -1464,10 +1435,8 @@ static void *RecordingContext = &RecordingContext;
 
 - (void)stopMovieRecording
 {
-    MXWeakify(self);
     dispatch_async(cameraQueue, ^{
         
-        MXStrongifyAndReturnIfNil(self);
         if ([self->movieFileOutput isRecording])
         {
             [self->movieFileOutput stopRecording];
@@ -1479,10 +1448,8 @@ static void *RecordingContext = &RecordingContext;
 {
     self.cameraCaptureButton.enabled = NO;
     
-    MXWeakify(self);
     dispatch_async(cameraQueue, ^{
         
-        MXStrongifyAndReturnIfNil(self);
         // Update the orientation on the still image output video connection before capturing.
         [[self->stillImageOutput connectionWithMediaType:AVMediaTypeVideo] setVideoOrientation:[[self->cameraPreviewLayer connection] videoOrientation]];
         
@@ -1538,16 +1505,12 @@ static void *RecordingContext = &RecordingContext;
 
 - (void)runStillImageCaptureAnimation
 {
-    MXWeakify(self);
     dispatch_async(dispatch_get_main_queue(), ^{
         
-        MXStrongifyAndReturnIfNil(self);
         [self->cameraPreviewLayer setOpacity:0.0];
         
-        MXWeakify(self);
         [UIView animateWithDuration:.25 animations:^{
             
-            MXStrongifyAndReturnIfNil(self);
             [self->cameraPreviewLayer setOpacity:1.0];
             
         }];
@@ -1571,10 +1534,8 @@ static void *RecordingContext = &RecordingContext;
     {
         BOOL isRecording = [change[NSKeyValueChangeNewKey] boolValue];
         
-        MXWeakify(self);
         dispatch_async(dispatch_get_main_queue(), ^{
             
-            MXStrongifyAndReturnIfNil(self);
             if (isRecording)
             {
                 self.cameraSwitchButton.enabled = NO;

--- a/Riot/Modules/MediaPicker/MediaPickerViewController.m
+++ b/Riot/Modules/MediaPicker/MediaPickerViewController.m
@@ -1287,10 +1287,8 @@ static void *RecordingContext = &RecordingContext;
         return;
     }
 
-    MXWeakify(self);
     dispatch_sync(cameraQueue, ^{
         
-        MXStrongifyAndReturnIfNil(self);
         self->frontCameraInput = nil;
         self->backCameraInput = nil;
         self->captureSession = nil;

--- a/Tchap/Modules/Room/Settings/RoomSettingsViewController.m
+++ b/Tchap/Modules/Room/Settings/RoomSettingsViewController.m
@@ -240,6 +240,9 @@ NSString *const kRoomSettingsBannedUserCellViewIdentifier = @"kRoomSettingsBanne
     // Screen tracking
     [[Analytics sharedInstance] trackScreen:@"RoomSettings"];
     
+    // Release the potential media picker
+    [self dismissMediaPicker];
+    
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(didUpdateRules:) name:kMXNotificationCenterDidUpdateRules object:nil];
     
     // Observe appDelegateDidTapStatusBarNotificationObserver.

--- a/Tchap/Modules/Settings/PhoneCountry/CountryPickerViewController.m
+++ b/Tchap/Modules/Settings/PhoneCountry/CountryPickerViewController.m
@@ -23,15 +23,13 @@
 @interface CountryPickerViewController ()
 {
     /**
-     Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
-     */
-    id kRiotDesignValuesDidChangeThemeNotificationObserver;
-    
-    /**
      The fake top view displayed in case of vertical bounce.
      */
     UIView *topview;
 }
+
+// Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+@property (nonatomic, weak) id kRiotDesignValuesDidChangeThemeNotificationObserver;
 
 @end
 
@@ -63,8 +61,10 @@
     [self.tableView addSubview:topview];
 
     // Observe user interface theme change.
-    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+    MXWeakify(self);
+    _kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
         
+        MXStrongifyAndReturnIfNil(self);
         [self userInterfaceThemeDidChange];
         
     }];
@@ -104,17 +104,14 @@
     [[Analytics sharedInstance] trackScreen:@"CountryPicker"];
 }
 
-- (void)destroy
+- (void)dealloc
 {
-    [super destroy];
-    
     [topview removeFromSuperview];
     topview = nil;
     
-    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    if (_kRiotDesignValuesDidChangeThemeNotificationObserver)
     {
-        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
-        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+        [[NSNotificationCenter defaultCenter] removeObserver:_kRiotDesignValuesDidChangeThemeNotificationObserver];
     }
 }
 

--- a/Tchap/Modules/Settings/SettingsViewController.m
+++ b/Tchap/Modules/Settings/SettingsViewController.m
@@ -113,15 +113,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
 {
     // Current alert (if any).
     UIAlertController *currentAlert;
-
-    // listener
-    id removedAccountObserver;
-    id accountUserInfoObserver;
-    id pushInfoUpdateObserver;
-    
-    id notificationCenterWillUpdateObserver;
-    id notificationCenterDidUpdateObserver;
-    id notificationCenterDidFailObserver;
     
     // picker
     MediaPickerViewController* mediaPicker;
@@ -166,15 +157,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
     // Observe kAppDelegateDidTapStatusBarNotification to handle tap on clock status bar.
     id kAppDelegateDidTapStatusBarNotificationObserver;
     
-    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
-    id kRiotDesignValuesDidChangeThemeNotificationObserver;
-    
-    // Postpone destroy operation when saving, pwd reset or email binding is in progress
-    BOOL isSavingInProgress;
-    BOOL isResetPwdInProgress;
-    BOOL is3PIDBindingInProgress;
-    blockSettingsViewController_onReadyToDestroy onReadyToDestroyHandler;
-    
     //
     UIAlertController *resetPwdAlertController;
 
@@ -187,9 +169,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
     NSTimer *keyExportsFileDeletionTimer;
     
     BOOL keepNewPhoneNumberEditing;
-    
-    // The current pushed view controller
-    UIViewController *pushedViewController;
 }
 
 /**
@@ -199,6 +178,12 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
 
 @property (weak, nonatomic) DeactivateAccountViewController *deactivateAccountViewController;
 @property (strong, nonatomic) id<Style> currentStyle;
+
+// Observer
+@property (nonatomic, weak) id kRiotDesignValuesDidChangeThemeNotificationObserver;
+@property (nonatomic, weak) id removedAccountObserver;
+@property (nonatomic, weak) id accountUserInfoObserver;
+@property (nonatomic, weak) id pushInfoUpdateObserver;
 
 @end
 
@@ -219,10 +204,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
     // Setup `MXKViewControllerHandling` properties
     self.enableBarTintColorStatusChange = NO;
     self.rageShakeManager = [RageShakeManager sharedManager];
-    
-    isSavingInProgress = NO;
-    isResetPwdInProgress = NO;
-    is3PIDBindingInProgress = NO;
 }
 
 - (void)viewDidLoad
@@ -245,35 +226,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
     self.tableView.rowHeight = UITableViewAutomaticDimension;
     self.tableView.estimatedRowHeight = 50;
     
-    // Add observer to handle removed accounts
-    removedAccountObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXKAccountManagerDidRemoveAccountNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
-        
-        if ([MXKAccountManager sharedManager].accounts.count)
-        {
-            // Refresh table to remove this account
-            [self refreshSettings];
-        }
-        
-    }];
-    
-    // Add observer to handle accounts update
-    accountUserInfoObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXKAccountUserInfoDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
-        
-        [self stopActivityIndicator];
-        
-        [self refreshSettings];
-        
-    }];
-    
-    // Add observer to push settings
-    pushInfoUpdateObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXKAccountPushKitActivityDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
-        
-        [self stopActivityIndicator];
-        
-        [self refreshSettings];
-        
-    }];
-    
     // Add each matrix session, to update the view controller appearance according to mx sessions state
     NSArray *sessions = [AppDelegate theDelegate].mxSessions;
     for (MXSession *mxSession in sessions)
@@ -286,12 +238,47 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
 
     
     // Observe user interface theme change.
-    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+    MXWeakify(self);
+    _kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
         
+        MXStrongifyAndReturnIfNil(self);
         [self userInterfaceThemeDidChange];
         
     }];
     [self userInterfaceThemeDidChange];
+    
+    
+    // Add observer to handle removed accounts
+    _removedAccountObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXKAccountManagerDidRemoveAccountNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        MXStrongifyAndReturnIfNil(self);
+        if ([MXKAccountManager sharedManager].accounts.count)
+        {
+            // Refresh table to remove this account
+            [self refreshSettings];
+        }
+        
+    }];
+    
+    // Add observer to handle accounts update
+    _accountUserInfoObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXKAccountUserInfoDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        MXStrongifyAndReturnIfNil(self);
+        [self stopActivityIndicator];
+        
+        [self refreshSettings];
+        
+    }];
+    
+    // Add observer to push settings
+    _pushInfoUpdateObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kMXKAccountPushKitActivityDidChangeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+        
+        MXStrongifyAndReturnIfNil(self);
+        [self stopActivityIndicator];
+        
+        [self refreshSettings];
+        
+    }];
 }
 
 - (void)userInterfaceThemeDidChange
@@ -332,11 +319,8 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
     // Dispose of any resources that can be recreated.
 }
 
-- (void)destroy
+- (void)dealloc
 {
-    // Release the potential pushed view controller
-    [self releasePushedViewController];
-    
     if (documentInteractionController)
     {
         [documentInteractionController dismissPreviewAnimated:NO];
@@ -344,31 +328,32 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
         documentInteractionController = nil;
     }
     
-    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    if (_kRiotDesignValuesDidChangeThemeNotificationObserver)
     {
-        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
-        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+        [[NSNotificationCenter defaultCenter] removeObserver:_kRiotDesignValuesDidChangeThemeNotificationObserver];
     }
-
-    if (isSavingInProgress || isResetPwdInProgress || is3PIDBindingInProgress)
+    
+    if (_removedAccountObserver)
     {
-        __weak typeof(self) weakSelf = self;
-        onReadyToDestroyHandler = ^() {
-            
-            if (weakSelf)
-            {
-                typeof(self) self = weakSelf;
-                [self destroy];
-            }
-            
-        };
+        [[NSNotificationCenter defaultCenter] removeObserver:_removedAccountObserver];
     }
-    else
+    
+    if (_accountUserInfoObserver)
     {
-        // Dispose all resources
-        [self reset];
-        
-        [super destroy];
+        [[NSNotificationCenter defaultCenter] removeObserver:_accountUserInfoObserver];
+    }
+    
+    if (_pushInfoUpdateObserver)
+    {
+        [[NSNotificationCenter defaultCenter] removeObserver:_pushInfoUpdateObserver];
+    }
+    
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    
+    if (deviceView)
+    {
+        [deviceView removeFromSuperview];
+        deviceView = nil;
     }
 }
 
@@ -395,8 +380,8 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
     // Screen tracking
     [[Analytics sharedInstance] trackScreen:@"Settings"];
     
-    // Release the potential pushed view controller
-    [self releasePushedViewController];
+    // Release the potential media picker
+    [self dismissMediaPicker];
     
     // Refresh display
     [self refreshSettings];
@@ -438,24 +423,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
         [resetPwdAlertController dismissViewControllerAnimated:NO completion:nil];
         resetPwdAlertController = nil;
     }
-
-    if (notificationCenterWillUpdateObserver)
-    {
-        [[NSNotificationCenter defaultCenter] removeObserver:notificationCenterWillUpdateObserver];
-        notificationCenterWillUpdateObserver = nil;
-    }
-    
-    if (notificationCenterDidUpdateObserver)
-    {
-        [[NSNotificationCenter defaultCenter] removeObserver:notificationCenterDidUpdateObserver];
-        notificationCenterDidUpdateObserver = nil;
-    }
-    
-    if (notificationCenterDidFailObserver)
-    {
-        [[NSNotificationCenter defaultCenter] removeObserver:notificationCenterDidFailObserver];
-        notificationCenterDidFailObserver = nil;
-    }
     
     if (kAppDelegateDidTapStatusBarNotificationObserver)
     {
@@ -468,37 +435,9 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
 
 - (void)pushViewController:(UIViewController*)viewController
 {
-    // Keep ref on pushed view controller
-    pushedViewController = viewController;
-    
     // Hide back button title
     self.navigationItem.backBarButtonItem =[[UIBarButtonItem alloc] initWithTitle:@"" style:UIBarButtonItemStylePlain target:nil action:nil];
-    
     [self.navigationController pushViewController:viewController animated:YES];
-}
-
-- (void)releasePushedViewController
-{
-    if (pushedViewController)
-    {
-        if ([pushedViewController isKindOfClass:[UINavigationController class]])
-        {
-            UINavigationController *navigationController = (UINavigationController*)pushedViewController;
-            for (id subViewController in navigationController.viewControllers)
-            {
-                if ([subViewController respondsToSelector:@selector(destroy)])
-                {
-                    [subViewController destroy];
-                }
-            }
-        }
-        else if ([pushedViewController respondsToSelector:@selector(destroy)])
-        {
-            [(id)pushedViewController destroy];
-        }
-        
-        pushedViewController = nil;
-    }
 }
 
 - (void)dismissKeyboard
@@ -507,38 +446,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
     [newPasswordTextField1 resignFirstResponder];
     [newPasswordTextField2 resignFirstResponder];
     [newPhoneNumberCell.mxkTextField resignFirstResponder];
-}
-
-- (void)reset
-{
-    // Remove observers
-    if (removedAccountObserver)
-    {
-        [[NSNotificationCenter defaultCenter] removeObserver:removedAccountObserver];
-        removedAccountObserver = nil;
-    }
-    
-    if (accountUserInfoObserver)
-    {
-        [[NSNotificationCenter defaultCenter] removeObserver:accountUserInfoObserver];
-        accountUserInfoObserver = nil;
-    }
-    
-    if (pushInfoUpdateObserver)
-    {
-        [[NSNotificationCenter defaultCenter] removeObserver:pushInfoUpdateObserver];
-        pushInfoUpdateObserver = nil;
-    }
-    
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-    
-    onReadyToDestroyHandler = nil;
-    
-    if (deviceView)
-    {
-        [deviceView removeFromSuperview];
-        deviceView = nil;
-    }
 }
 
 -(void)setNewPhoneEditingEnabled:(BOOL)newPhoneEditingEnabled
@@ -569,7 +476,7 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
 
 - (void)showValidationMsisdnDialogWithMessage:(NSString*)message for3PID:(MXK3PID*)threePID
 {
-    __weak typeof(self) weakSelf = self;
+    MXWeakify(self);
     
     [currentAlert dismissViewControllerAnimated:NO completion:nil];
     currentAlert = [UIAlertController alertControllerWithTitle:[NSBundle mxk_localizedStringForKey:@"account_msisdn_validation_title"] message:message preferredStyle:UIAlertControllerStyleAlert];
@@ -578,16 +485,13 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
                                                      style:UIAlertActionStyleDefault
                                                    handler:^(UIAlertAction * action) {
                                                        
-                                                       if (weakSelf)
-                                                       {
-                                                           typeof(self) self = weakSelf;
-                                                           self->currentAlert = nil;
-                                                           
-                                                           [self stopActivityIndicator];
-                                                           
-                                                           // Reset new phone adding
-                                                           self.newPhoneEditingEnabled = NO;
-                                                       }
+                                                       MXStrongifyAndReturnIfNil(self);
+                                                       self->currentAlert = nil;
+                                                       
+                                                       [self stopActivityIndicator];
+                                                       
+                                                       // Reset new phone adding
+                                                       self.newPhoneEditingEnabled = NO;
                                                        
                                                    }]];
     
@@ -601,144 +505,100 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
                                                      style:UIAlertActionStyleDefault
                                                    handler:^(UIAlertAction * action) {
                                                        
-                                                       if (weakSelf)
+                                                       MXStrongifyAndReturnIfNil(self);
+                                                       UITextField *textField = [self->currentAlert textFields].firstObject;
+                                                       NSString *smsCode = textField.text;
+                                                       
+                                                       self->currentAlert = nil;
+                                                       
+                                                       if (smsCode.length)
                                                        {
-                                                           typeof(self) self = weakSelf;
-                                                           
-                                                           UITextField *textField = [self->currentAlert textFields].firstObject;
-                                                           NSString *smsCode = textField.text;
-                                                           
-                                                           self->currentAlert = nil;
-                                                           
-                                                           if (smsCode.length)
-                                                           {
-                                                               self->is3PIDBindingInProgress = YES;
+                                                           // We retain 'self' on purpose in the blocks of the 2 operations: "submitValidationToken" and "add3PIDToUser",
+                                                           // in order to keep them running when the user leaves the settings screen.
+                                                           [threePID submitValidationToken:smsCode success:^{
                                                                
-                                                               [threePID submitValidationToken:smsCode success:^{
+                                                               // We always bind the phone numbers when registering, so let's do the same here
+                                                               [threePID add3PIDToUser:YES success:^{
                                                                    
-                                                                   // We always bind the phone numbers when registering, so let's do the same here
-                                                                   [threePID add3PIDToUser:YES success:^{
+                                                                   // Check whether the settings screen is still visible
+                                                                   if (self.navigationController)
+                                                                   {
+                                                                       [self stopActivityIndicator];
                                                                        
-                                                                       if (weakSelf)
-                                                                       {
-                                                                           typeof(self) self = weakSelf;
-                                                                           self->is3PIDBindingInProgress = NO;
-                                                                           
-                                                                           // Check whether destroy has been called during the binding
-                                                                           if (self->onReadyToDestroyHandler)
-                                                                           {
-                                                                               // Ready to destroy
-                                                                               self->onReadyToDestroyHandler();
-                                                                               self->onReadyToDestroyHandler = nil;
-                                                                           }
-                                                                           else
-                                                                           {
-                                                                               [self stopActivityIndicator];
-                                                                               
-                                                                               // Reset new phone adding
-                                                                               self.newPhoneEditingEnabled = NO;
-                                                                               
-                                                                               // Update linked 3pids
-                                                                               [self loadAccount3PIDs];
-                                                                           }
-                                                                       }
+                                                                       // Reset new phone adding
+                                                                       self.newPhoneEditingEnabled = NO;
                                                                        
-                                                                   } failure:^(NSError *error) {
-                                                                       
-                                                                       NSLog(@"[SettingsViewController] Failed to bind phone number");
-                                                                       
-                                                                       if (weakSelf)
-                                                                       {
-                                                                           typeof(self) self = weakSelf;
-                                                                           self->is3PIDBindingInProgress = NO;
-                                                                           
-                                                                           // Check whether destroy has been called during phone binding
-                                                                           if (self->onReadyToDestroyHandler)
-                                                                           {
-                                                                               // Ready to destroy
-                                                                               self->onReadyToDestroyHandler();
-                                                                               self->onReadyToDestroyHandler = nil;
-                                                                           }
-                                                                           else
-                                                                           {
-                                                                               [self stopActivityIndicator];
-                                                                               
-                                                                               NSString *myUserId = self.mainSession.myUser.userId; // TODO: Hanlde multi-account
-                                                                               [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
-                                                                           }
-                                                                       }
-                                                                       
-                                                                   }];
+                                                                       // Update linked 3pids
+                                                                       [self loadAccount3PIDs];
+                                                                   }
                                                                    
                                                                } failure:^(NSError *error) {
                                                                    
-                                                                   NSLog(@"[SettingsViewController] Failed to submit the sms token");
+                                                                   NSLog(@"[SettingsViewController] Failed to bind phone number");
                                                                    
-                                                                   if (weakSelf)
+                                                                   // Check whether the settings screen is still visible
+                                                                   if (self.navigationController)
                                                                    {
-                                                                       typeof(self) self = weakSelf;
-                                                                       self->is3PIDBindingInProgress = NO;
+                                                                       [self stopActivityIndicator];
                                                                        
-                                                                       // Check whether destroy has been called during phone binding
-                                                                       if (self->onReadyToDestroyHandler)
-                                                                       {
-                                                                           // Ready to destroy
-                                                                           self->onReadyToDestroyHandler();
-                                                                           self->onReadyToDestroyHandler = nil;
-                                                                       }
-                                                                       else
-                                                                       {
-                                                                           // Ignore connection cancellation error
-                                                                           if (([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled))
-                                                                           {
-                                                                               [self stopActivityIndicator];
-                                                                               return;
-                                                                           }
-                                                                           
-                                                                           // Alert user
-                                                                           NSString *title = [error.userInfo valueForKey:NSLocalizedFailureReasonErrorKey];
-                                                                           NSString *msg = [error.userInfo valueForKey:NSLocalizedDescriptionKey];
-                                                                           if (!title)
-                                                                           {
-                                                                               if (msg)
-                                                                               {
-                                                                                   title = msg;
-                                                                                   msg = nil;
-                                                                               }
-                                                                               else
-                                                                               {
-                                                                                   title = [NSBundle mxk_localizedStringForKey:@"error"];
-                                                                               }
-                                                                           }
-                                                                           
-                                                                           
-                                                                           self->currentAlert = [UIAlertController alertControllerWithTitle:title message:msg preferredStyle:UIAlertControllerStyleAlert];
-                                                                           
-                                                                           [self->currentAlert addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"ok"] style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
-                                                                               
-                                                                               if (weakSelf)
-                                                                               {
-                                                                                   typeof(self) self = weakSelf;
-                                                                                   self->currentAlert = nil;
-                                                                                   
-                                                                                   // Ask again the sms token
-                                                                                   [self showValidationMsisdnDialogWithMessage:message for3PID:threePID];
-                                                                               }
-                                                                               
-                                                                           }]];
-                                                                           
-                                                                           [self->currentAlert mxk_setAccessibilityIdentifier: @"SettingsVCErrorAlert"];
-                                                                           [self presentViewController:self->currentAlert animated:YES completion:nil];
-                                                                       }
+                                                                       NSString *myUserId = self.mainSession.myUser.userId; // TODO: Handle multi-account
+                                                                       [[NSNotificationCenter defaultCenter] postNotificationName:kMXKErrorNotification object:error userInfo:myUserId ? @{kMXKErrorUserIdKey: myUserId} : nil];
                                                                    }
                                                                    
                                                                }];
-                                                           }
-                                                           else
-                                                           {
-                                                               // Ask again the sms token
-                                                               [self showValidationMsisdnDialogWithMessage:message for3PID:threePID];
-                                                           }
+                                                               
+                                                           } failure:^(NSError *error) {
+                                                               
+                                                               NSLog(@"[SettingsViewController] Failed to submit the sms token");
+                                                               
+                                                               // Check whether the settings screen is still visible
+                                                               if (self.navigationController)
+                                                               {
+                                                                   // Ignore connection cancellation error
+                                                                   if (([error.domain isEqualToString:NSURLErrorDomain] && error.code == NSURLErrorCancelled))
+                                                                   {
+                                                                       [self stopActivityIndicator];
+                                                                       return;
+                                                                   }
+                                                                   
+                                                                   // Alert user
+                                                                   NSString *title = [error.userInfo valueForKey:NSLocalizedFailureReasonErrorKey];
+                                                                   NSString *msg = [error.userInfo valueForKey:NSLocalizedDescriptionKey];
+                                                                   if (!title)
+                                                                   {
+                                                                       if (msg)
+                                                                       {
+                                                                           title = msg;
+                                                                           msg = nil;
+                                                                       }
+                                                                       else
+                                                                       {
+                                                                           title = [NSBundle mxk_localizedStringForKey:@"error"];
+                                                                       }
+                                                                   }
+                                                                   
+                                                                   MXWeakify(self);
+                                                                   self->currentAlert = [UIAlertController alertControllerWithTitle:title message:msg preferredStyle:UIAlertControllerStyleAlert];
+                                                                   
+                                                                   [self->currentAlert addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"ok"] style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
+                                                                       
+                                                                       MXStrongifyAndReturnIfNil(self);
+                                                                       self->currentAlert = nil;
+                                                                       // Ask again the sms token
+                                                                       [self showValidationMsisdnDialogWithMessage:message for3PID:threePID];
+                                                                       
+                                                                   }]];
+                                                                   
+                                                                   [self->currentAlert mxk_setAccessibilityIdentifier: @"SettingsVCErrorAlert"];
+                                                                   [self presentViewController:self->currentAlert animated:YES completion:nil];
+                                                               }
+                                                               
+                                                           }];
+                                                       }
+                                                       else
+                                                       {
+                                                           // Ask again the sms token
+                                                           [self showValidationMsisdnDialogWithMessage:message for3PID:threePID];
                                                        }
                                                        
                                                    }]];
@@ -2451,8 +2311,6 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
     
     self.navigationItem.rightBarButtonItem.enabled = NO;
     [self startActivityIndicator];
-    isSavingInProgress = YES;
-    __weak typeof(self) weakSelf = self;
     
     MXKAccount* account = [MXKAccountManager sharedManager].activeAccounts.firstObject;
     
@@ -2462,30 +2320,19 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
         UIImage *updatedPicture = [MXKTools forceImageOrientationUp:newAvatarImage];
         
         // Upload picture
+        // We retain 'self' on purpose during this operation in order to keep saving changes when the user leaves the settings screen.
         MXMediaLoader *uploader = [MXMediaManager prepareUploaderWithMatrixSession:account.mxSession initialRange:0 andRange:1.0];
-        
         [uploader uploadData:UIImageJPEGRepresentation(updatedPicture, 0.5) filename:nil mimeType:@"image/jpeg" success:^(NSString *url) {
             
-            if (weakSelf)
-            {
-                typeof(self) self = weakSelf;
-                
-                // Store uploaded picture url and trigger picture saving
-                self->uploadedAvatarURL = url;
-                self->newAvatarImage = nil;
-                [self onSave:nil];
-            }
-            
+            // Store uploaded picture url and trigger picture saving
+            self->uploadedAvatarURL = url;
+            self->newAvatarImage = nil;
+            [self onSave:nil];
             
         } failure:^(NSError *error) {
             
             NSLog(@"[SettingsViewController] Failed to upload image");
-            
-            if (weakSelf)
-            {
-                typeof(self) self = weakSelf;
-                [self handleErrorDuringProfileChangeSaving:error];
-            }
+            [self handleErrorDuringProfileChangeSaving:error];
             
         }];
         
@@ -2493,44 +2340,27 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
     }
     else if (uploadedAvatarURL)
     {
-        [account setUserAvatarUrl:uploadedAvatarURL
-                             success:^{
-                                 
-                                 if (weakSelf)
-                                 {
-                                     typeof(self) self = weakSelf;
-                                     self->uploadedAvatarURL = nil;
-                                     [self onSave:nil];
-                                 }
-                                 
-                             }
-                             failure:^(NSError *error) {
-                                 
-                                 NSLog(@"[SettingsViewController] Failed to set avatar url");
-                                
-                                 if (weakSelf)
-                                 {
-                                     typeof(self) self = weakSelf;
-                                     [self handleErrorDuringProfileChangeSaving:error];
-                                 }
-                                 
-                             }];
+        // We retain 'self' on purpose during this operation in order to keep saving changes when the user leaves the settings screen.
+        [account setUserAvatarUrl:uploadedAvatarURL success:^{
+            
+            self->uploadedAvatarURL = nil;
+            [self onSave:nil];
+            
+        } failure:^(NSError *error) {
+            
+            NSLog(@"[SettingsViewController] Failed to set avatar url");
+            [self handleErrorDuringProfileChangeSaving:error];
+            
+        }];
         
         return;
     }
     
     // Backup is complete
-    isSavingInProgress = NO;
     [self stopActivityIndicator];
     
-    // Check whether destroy has been called durign saving
-    if (onReadyToDestroyHandler)
-    {
-        // Ready to destroy
-        onReadyToDestroyHandler();
-        onReadyToDestroyHandler = nil;
-    }
-    else
+    // Check whether the settings screen is still visible
+    if (self.navigationController)
     {
         [self.tableView reloadData];
     }
@@ -2888,118 +2718,74 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
 
 - (void)displayPasswordAlert
 {
-    __weak typeof(self) weakSelf = self;
+    MXWeakify(self);
     [resetPwdAlertController dismissViewControllerAnimated:NO completion:nil];
     
     resetPwdAlertController = [UIAlertController alertControllerWithTitle:NSLocalizedStringFromTable(@"settings_change_password", @"Vector", nil) message:nil preferredStyle:UIAlertControllerStyleAlert];
     resetPwdAlertController.accessibilityLabel=@"ChangePasswordAlertController";
     savePasswordAction = [UIAlertAction actionWithTitle:NSLocalizedStringFromTable(@"save", @"Vector", nil) style:UIAlertActionStyleDefault handler:^(UIAlertAction * action) {
         
-        if (weakSelf)
+        MXStrongifyAndReturnIfNil(self);
+        self->resetPwdAlertController = nil;
+        
+        if ([MXKAccountManager sharedManager].activeAccounts.count > 0)
         {
-            typeof(self) self = weakSelf;
+            [self startActivityIndicator];
             
-            self->resetPwdAlertController = nil;
-            
-            if ([MXKAccountManager sharedManager].activeAccounts.count > 0)
-            {
-                [self startActivityIndicator];
-                self->isResetPwdInProgress = YES;
+            // We retain 'self' on purpose during this operation in order to keep saving changes when the user leaves the settings screen.
+            MXKAccount* account = [MXKAccountManager sharedManager].activeAccounts.firstObject;
+            [account changePassword:self->currentPasswordTextField.text with:self->newPasswordTextField1.text success:^{
                 
-                MXKAccount* account = [MXKAccountManager sharedManager].activeAccounts.firstObject;
+                [self stopActivityIndicator];
                 
-                [account changePassword:currentPasswordTextField.text with:newPasswordTextField1.text success:^{
+                // Display a successful message only if the settings screen is still visible
+                if (self.navigationController)
+                {
+                    MXWeakify(self);
+                    [self->currentAlert dismissViewControllerAnimated:NO completion:nil];
                     
-                    if (weakSelf)
-                    {
-                        typeof(self) self = weakSelf;
-                        
-                        self->isResetPwdInProgress = NO;
-                        [self stopActivityIndicator];
-                        
-                        // Display a successful message only if the settings screen is still visible (destroy is not called yet)
-                        if (!self->onReadyToDestroyHandler)
-                        {
-                            [self->currentAlert dismissViewControllerAnimated:NO completion:nil];
-                            
-                            self->currentAlert = [UIAlertController alertControllerWithTitle:nil message:NSLocalizedStringFromTable(@"settings_password_updated", @"Vector", nil) preferredStyle:UIAlertControllerStyleAlert];
-                            
-                            [self->currentAlert addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"ok"]
-                                                                             style:UIAlertActionStyleDefault
-                                                                           handler:^(UIAlertAction * action) {
-                                                                               
-                                                                               if (weakSelf)
-                                                                               {
-                                                                                   typeof(self) self = weakSelf;
-                                                                                   self->currentAlert = nil;
-                                                                                   
-                                                                                   // Check whether destroy has been called durign pwd change
-                                                                                   if (self->onReadyToDestroyHandler)
-                                                                                   {
-                                                                                       // Ready to destroy
-                                                                                       self->onReadyToDestroyHandler();
-                                                                                       self->onReadyToDestroyHandler = nil;
-                                                                                   }
-                                                                               }
-                                                                               
-                                                                           }]];
-                            
-                            [self->currentAlert mxk_setAccessibilityIdentifier:@"SettingsVCOnPasswordUpdatedAlert"];
-                            [self presentViewController:self->currentAlert animated:YES completion:nil];
-                        }
-                        else
-                        {
-                            // Ready to destroy
-                            self->onReadyToDestroyHandler();
-                            self->onReadyToDestroyHandler = nil;
-                        }
-                    }
+                    self->currentAlert = [UIAlertController alertControllerWithTitle:nil message:NSLocalizedStringFromTable(@"settings_password_updated", @"Vector", nil) preferredStyle:UIAlertControllerStyleAlert];
                     
-                } failure:^(NSError *error) {
+                    [self->currentAlert addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"ok"]
+                                                                           style:UIAlertActionStyleDefault
+                                                                         handler:^(UIAlertAction * action) {
+                                                                             
+                                                                             MXStrongifyAndReturnIfNil(self);
+                                                                             self->currentAlert = nil;
+                                                                             
+                                                                         }]];
                     
-                    if (weakSelf)
-                    {
-                        typeof(self) self = weakSelf;
-                        
-                        self->isResetPwdInProgress = NO;
-                        [self stopActivityIndicator];
-                        
-                        // Display a failure message on the current screen
-                        UIViewController *rootViewController = [AppDelegate theDelegate].window.rootViewController;
-                        if (rootViewController)
-                        {
-                            [self->currentAlert dismissViewControllerAnimated:NO completion:nil];
-                            
-                            self->currentAlert = [UIAlertController alertControllerWithTitle:nil message:NSLocalizedStringFromTable(@"settings_fail_to_update_password", @"Vector", nil) preferredStyle:UIAlertControllerStyleAlert];
-                            
-                            [self->currentAlert addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"ok"]
+                    [self->currentAlert mxk_setAccessibilityIdentifier:@"SettingsVCOnPasswordUpdatedAlert"];
+                    [self presentViewController:self->currentAlert animated:YES completion:nil];
+                }
+                
+            } failure:^(NSError *error) {
+                
+                [self stopActivityIndicator];
+                
+                // Display a failure message on the current screen
+                UIViewController *rootViewController = [AppDelegate theDelegate].window.rootViewController;
+                if (rootViewController)
+                {
+                    MXWeakify(self);
+                    [self->currentAlert dismissViewControllerAnimated:NO completion:nil];
+                    
+                    self->currentAlert = [UIAlertController alertControllerWithTitle:nil message:NSLocalizedStringFromTable(@"settings_fail_to_update_password", @"Vector", nil) preferredStyle:UIAlertControllerStyleAlert];
+                    
+                    [self->currentAlert addAction:[UIAlertAction actionWithTitle:[NSBundle mxk_localizedStringForKey:@"ok"]
                                                                                    style:UIAlertActionStyleDefault
                                                                                  handler:^(UIAlertAction * action) {
                                                                                      
-                                                                                     if (weakSelf)
-                                                                                     {
-                                                                                         typeof(self) self = weakSelf;
-                                                                                         
-                                                                                         self->currentAlert = nil;
-                                                                                         
-                                                                                         // Check whether destroy has been called durign pwd change
-                                                                                         if (self->onReadyToDestroyHandler)
-                                                                                         {
-                                                                                             // Ready to destroy
-                                                                                             self->onReadyToDestroyHandler();
-                                                                                             self->onReadyToDestroyHandler = nil;
-                                                                                         }
-                                                                                     }
+                                                                                     MXStrongifyAndReturnIfNil(self);
+                                                                                     self->currentAlert = nil;
                                                                                      
                                                                                  }]];
-                            
-                            [self->currentAlert mxk_setAccessibilityIdentifier:@"SettingsVCPasswordChangeFailedAlert"];
-                            [rootViewController presentViewController:self->currentAlert animated:YES completion:nil];
-                        }
-                    }
                     
-                }];
-            }
+                    [self->currentAlert mxk_setAccessibilityIdentifier:@"SettingsVCPasswordChangeFailedAlert"];
+                    [rootViewController presentViewController:self->currentAlert animated:YES completion:nil];
+                }
+                
+            }];
         }
         
     }];
@@ -3010,54 +2796,39 @@ typedef void (^blockSettingsViewController_onReadyToDestroy)(void);
     
     UIAlertAction* cancel = [UIAlertAction actionWithTitle:@"Cancel" style:UIAlertActionStyleCancel handler:^(UIAlertAction * action) {
         
-        if (weakSelf)
-        {
-            typeof(self) self = weakSelf;
-            
-            self->resetPwdAlertController = nil;
-        }
+        MXStrongifyAndReturnIfNil(self);
+        self->resetPwdAlertController = nil;
         
     }];
     
     [resetPwdAlertController addTextFieldWithConfigurationHandler:^(UITextField *textField) {
         
-        if (weakSelf)
-        {
-            typeof(self) self = weakSelf;
-            
-            self->currentPasswordTextField = textField;
-            self->currentPasswordTextField.placeholder = NSLocalizedStringFromTable(@"settings_old_password", @"Vector", nil);
-            self->currentPasswordTextField.secureTextEntry = YES;
-            [self->currentPasswordTextField addTarget:self action:@selector(passwordTextFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
-        }
+        MXStrongifyAndReturnIfNil(self);
+        self->currentPasswordTextField = textField;
+        self->currentPasswordTextField.placeholder = NSLocalizedStringFromTable(@"settings_old_password", @"Vector", nil);
+        self->currentPasswordTextField.secureTextEntry = YES;
+        [self->currentPasswordTextField addTarget:self action:@selector(passwordTextFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
          
      }];
     
     [resetPwdAlertController addTextFieldWithConfigurationHandler:^(UITextField *textField) {
         
-        if (weakSelf)
-        {
-            typeof(self) self = weakSelf;
-            
-            self->newPasswordTextField1 = textField;
-            self->newPasswordTextField1.placeholder = NSLocalizedStringFromTable(@"settings_new_password", @"Vector", nil);
-            self->newPasswordTextField1.secureTextEntry = YES;
-            [self->newPasswordTextField1 addTarget:self action:@selector(passwordTextFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
-        }
+        MXStrongifyAndReturnIfNil(self);
+        self->newPasswordTextField1 = textField;
+        self->newPasswordTextField1.placeholder = NSLocalizedStringFromTable(@"settings_new_password", @"Vector", nil);
+        self->newPasswordTextField1.secureTextEntry = YES;
+        [self->newPasswordTextField1 addTarget:self action:@selector(passwordTextFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
         
     }];
     
     [resetPwdAlertController addTextFieldWithConfigurationHandler:^(UITextField *textField) {
         
-        if (weakSelf)
-        {
-            typeof(self) self = weakSelf;
-            
-            self->newPasswordTextField2 = textField;
-            self->newPasswordTextField2.placeholder = NSLocalizedStringFromTable(@"settings_confirm_password", @"Vector", nil);
-            self->newPasswordTextField2.secureTextEntry = YES;
-            [self->newPasswordTextField2 addTarget:self action:@selector(passwordTextFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
-        }
+        MXStrongifyAndReturnIfNil(self);
+        self->newPasswordTextField2 = textField;
+        self->newPasswordTextField2.placeholder = NSLocalizedStringFromTable(@"settings_confirm_password", @"Vector", nil);
+        self->newPasswordTextField2.secureTextEntry = YES;
+        [self->newPasswordTextField2 addTarget:self action:@selector(passwordTextFieldDidChange:) forControlEvents:UIControlEventEditingChanged];
+        
     }];
 
     


### PR DESCRIPTION
"destroy" operation was not called in the current Tchap implementation, but we don't need it anymore.
Indeed removing all the implicit retains of "self" fixes the issue.
CAUTION: we retain explicitly "self" for the 3 following operations: saving, pwd reset and msisdn binding, in order to let them running when the user leaves the settings screen.

Note: we clean here MediaPickerViewController too, by removing all the implicit retains of "self".

"destroy" operation is not anymore required to release the instances of the following class: SettingsViewController, MediaPickerViewController, WebViewViewController, AlbumContentViewController.