### PR TITLE
Private Room creation: change history visibility to "invited"

### DIFF
--- a/Tchap/Managers/Room/RoomService.swift
+++ b/Tchap/Managers/Room/RoomService.swift
@@ -120,7 +120,7 @@ final class RoomService: RoomServiceType {
             alias = self.defaultAlias(for: name)
         } else {
             preset = .privateChat
-            historyVisibility = nil
+            historyVisibility = kMXRoomHistoryVisibilityInvited
             alias = nil
         }
         


### PR DESCRIPTION
Par défaut les utilisateurs ne voient pas l’historique avant leur invitation pour les salons privés

#154