### PR TITLE
Update MatrixSDK:

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -133,10 +133,10 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   MatrixKit:
-    :commit: 892230ee36e07d6636f388f573c61598254df041
+    :commit: 825a1d253648ed969941f1996a855d242d5b0270
     :git: https://github.com/matrix-org/matrix-ios-kit.git
   MatrixSDK:
-    :commit: 3a2e43008170e5c29c1f04987c6cce20b1547362
+    :commit: 505fda58f1a32079590f94c3bf5328ae0d7a200a
     :git: https://github.com/matrix-org/matrix-ios-sdk.git
   PiwikTracker:
     :commit: dfb048f25f4eefbe13ff7515c3c1c2cad5d94491

--- a/Tchap/Managers/Registration/RegistrationService.swift
+++ b/Tchap/Managers/Registration/RegistrationService.swift
@@ -101,11 +101,15 @@ final class RegistrationService: RegistrationServiceType {
             self.registrationOperation = nil
             switch registrationResult {
             case .success(let credentials):
-                do {
-                    try self.addAccount(for: credentials, identityServerURL: identityServer)
-                    completion(MXResponse.success(credentials.userId))
-                } catch {
-                    completion(MXResponse.failure(error))
+                if let userId = credentials.userId {
+                    do {
+                        try self.addAccount(for: credentials, identityServerURL: identityServer)
+                        completion(MXResponse.success(userId))
+                    } catch {
+                        completion(MXResponse.failure(error))
+                    }
+                } else {
+                    completion(MXResponse.failure(AuthenticationServiceError.failToCreateAccount))
                 }
             case .failure(let error):
                 completion(MXResponse.failure(error))
@@ -197,14 +201,14 @@ final class RegistrationService: RegistrationServiceType {
             switch response {
             case .success(let jsonResponse):
                 
-                guard let credentials = MXCredentials(fromJSON: jsonResponse), credentials.userId != nil, credentials.accessToken != nil else {
+                guard let loginResponse = MXLoginResponse(fromJSON: jsonResponse), loginResponse.userId != nil, loginResponse.accessToken != nil else {
                     let error = NSError(domain: MXKAuthErrorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey: Bundle.mxk_localizedString(forKey: "not_supported_yet")])
                     completion(MXResponse.failure(error))
                     return
                 }
                 
-                // Workaround: HS does not return the right URL. Use the one we used to make the request
-                credentials.homeServer = restClient.homeserver
+                // Build credentials
+                let credentials = MXCredentials(loginResponse: loginResponse, andDefaultCredentials: restClient.credentials)
                 // Report the certificate trusted by user (if any)
                 credentials.allowedCertificate = restClient.allowedCertificate
                 


### PR DESCRIPTION
Fix API break: MXCredentials: Create a new data model for it, separated from the CS API response data model (new MXLoginResponse class).