### PR TITLE
Bug Fix: Room history: the most recent event is not displayed

### DIFF
--- a/Tchap/Modules/Room/RoomViewController.m
+++ b/Tchap/Modules/Room/RoomViewController.m
@@ -182,9 +182,6 @@ NSString *const RoomErrorDomain = @"RoomErrorDomain";
     
     // The right bar button items back up.
     NSArray<UIBarButtonItem *> *rightBarButtonItems;
-
-    // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
-    id kRiotDesignValuesDidChangeThemeNotificationObserver;
     
     // Tell whether the input text field is in send reply mode. If true typed message will be sent to highlighted event.
     BOOL isInReplyMode;
@@ -214,6 +211,9 @@ NSString *const RoomErrorDomain = @"RoomErrorDomain";
 
 // Direct chat target user when create a discussion without associated room
 @property (nonatomic, strong) User *discussionTargetUser;
+
+// Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
+@property (nonatomic, weak) id kRiotDesignValuesDidChangeThemeNotificationObserver;
 
 /**
  Action used to handle some buttons.
@@ -405,8 +405,10 @@ NSString *const RoomErrorDomain = @"RoomErrorDomain";
     }
     
     // Observe user interface theme change.
-    kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+    MXWeakify(self);
+    _kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
         
+        MXStrongifyAndReturnIfNil(self);
         [self userInterfaceThemeDidChange];
         
     }];
@@ -1084,7 +1086,7 @@ NSString *const RoomErrorDomain = @"RoomErrorDomain";
     }];
 }
 
-- (void)destroy
+- (void)dealloc
 {
     rightBarButtonItems = nil;
     for (UIBarButtonItem *barButtonItem in self.navigationItem.rightBarButtonItems)
@@ -1106,10 +1108,9 @@ NSString *const RoomErrorDomain = @"RoomErrorDomain";
     
     [self removeTypingNotificationsListener];
     
-    if (kRiotDesignValuesDidChangeThemeNotificationObserver)
+    if (_kRiotDesignValuesDidChangeThemeNotificationObserver)
     {
-        [[NSNotificationCenter defaultCenter] removeObserver:kRiotDesignValuesDidChangeThemeNotificationObserver];
-        kRiotDesignValuesDidChangeThemeNotificationObserver = nil;
+        [[NSNotificationCenter defaultCenter] removeObserver:_kRiotDesignValuesDidChangeThemeNotificationObserver];
     }
     if (kAppDelegateDidTapStatusBarNotificationObserver)
     {
@@ -1157,8 +1158,6 @@ NSString *const RoomErrorDomain = @"RoomErrorDomain";
     missedDiscussionsBadgeLabel = nil;
     
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXEventDidChangeSentStateNotification object:nil];
-    
-    [super destroy];
 }
 
 #pragma mark - Tchap

--- a/Tchap/Modules/Room/RoomViewController.m
+++ b/Tchap/Modules/Room/RoomViewController.m
@@ -213,7 +213,7 @@ NSString *const RoomErrorDomain = @"RoomErrorDomain";
 @property (nonatomic, strong) User *discussionTargetUser;
 
 // Observe kRiotDesignValuesDidChangeThemeNotification to handle user interface theme change.
-@property (nonatomic, weak) id kRiotDesignValuesDidChangeThemeNotificationObserver;
+@property (nonatomic, weak) id themeDidChangeNotificationObserver;
 
 /**
  Action used to handle some buttons.
@@ -406,7 +406,7 @@ NSString *const RoomErrorDomain = @"RoomErrorDomain";
     
     // Observe user interface theme change.
     MXWeakify(self);
-    _kRiotDesignValuesDidChangeThemeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
+    _themeDidChangeNotificationObserver = [[NSNotificationCenter defaultCenter] addObserverForName:kRiotDesignValuesDidChangeThemeNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notif) {
         
         MXStrongifyAndReturnIfNil(self);
         [self userInterfaceThemeDidChange];
@@ -1108,9 +1108,9 @@ NSString *const RoomErrorDomain = @"RoomErrorDomain";
     
     [self removeTypingNotificationsListener];
     
-    if (_kRiotDesignValuesDidChangeThemeNotificationObserver)
+    if (_themeDidChangeNotificationObserver)
     {
-        [[NSNotificationCenter defaultCenter] removeObserver:_kRiotDesignValuesDidChangeThemeNotificationObserver];
+        [[NSNotificationCenter defaultCenter] removeObserver:_themeDidChangeNotificationObserver];
     }
     if (kAppDelegateDidTapStatusBarNotificationObserver)
     {


### PR DESCRIPTION
- Bug Fix: Room history: the most recent event is not displayed
- Bug Fix: Pb with badge notifications

These 2 issues were due to the fact that RoomViewConntroller was not deallocated.
"destroy" operation is not called in the current Tchap implementation, but we don't need it anymore.
Indeed removing all the implicit retains of "self" fixes the issue.

#136 #189 