### PR TITLE
Bug Fix - The app may be stuck on the device verification screen

### DIFF
--- a/Tchap/Modules/Application/Legacy/LegacyAppDelegate.m
+++ b/Tchap/Modules/Application/Legacy/LegacyAppDelegate.m
@@ -3339,7 +3339,7 @@ NSString *const kLegacyAppDelegateDidLoginNotification = @"kLegacyAppDelegateDid
                             [self checkPendingRoomKeyRequests];
                         }];
 
-                        self->isCheckPendingKeyRequestsInProgress = FALSE;
+                        self->isCheckPendingKeyRequestsInProgress = NO;
                         [self->roomKeyRequestViewController show];
                     };
 
@@ -3356,7 +3356,7 @@ NSString *const kLegacyAppDelegateDidLoginNotification = @"kLegacyAppDelegateDid
                 else
                 {
                     NSLog(@"[AppDelegate] checkPendingRoomKeyRequestsInSession: No details found for device %@:%@", userId, deviceId);
-                    self->isCheckPendingKeyRequestsInProgress = FALSE;
+                    self->isCheckPendingKeyRequestsInProgress = NO;
                     // Ignore this device to avoid to loop on it
                     [mxSession.crypto ignoreAllPendingKeyRequestsFromUser:userId andDevice:deviceId onComplete:^{
                         // And check next requests
@@ -3367,14 +3367,14 @@ NSString *const kLegacyAppDelegateDidLoginNotification = @"kLegacyAppDelegateDid
             } failure:^(NSError *error) {
                 // Retry
                 MXStrongifyAndReturnIfNil(self);
-                self->isCheckPendingKeyRequestsInProgress = FALSE;
+                self->isCheckPendingKeyRequestsInProgress = NO;
                 NSLog(@"[AppDelegate] checkPendingRoomKeyRequestsInSession: Failed to download device keys. Retry");
                 [self checkPendingRoomKeyRequests];
             }];
         }
         else
         {
-            self->isCheckPendingKeyRequestsInProgress = FALSE;
+            self->isCheckPendingKeyRequestsInProgress = NO;
         }
     }];
 }


### PR DESCRIPTION
This happens when several check of the pending room key requests are triggered simultaneously.
For example when we resume the app after added a new device.
This multiple requests involve an issue on the dialog handling (The screen is displayed, but the model lost its delegate)

We fix this here by preventing the app from checking several times the pending requests