### PR TITLE
Bug Fix: Join a federated room failed

### DIFF
--- a/TCHAP_CHANGES.rst
+++ b/TCHAP_CHANGES.rst
@@ -1,3 +1,9 @@
+Changes in Tchap 1.0.XX (2020-xx-xx)
+===================================================
+ 
+Bug Fixes:
+ * Join a federated room failed PR #318
+
 Changes in Tchap 1.0.25 (2020-08-14)
 ===================================================
  

--- a/Tchap/Modules/RoomPreview/RoomPreviewCoordinator.swift
+++ b/Tchap/Modules/RoomPreview/RoomPreviewCoordinator.swift
@@ -94,7 +94,9 @@ final class RoomPreviewCoordinator: NSObject, RoomPreviewCoordinatorType {
         let signURL: URL?
         
         // We promote here join by room alias instead of room id when an alias is available, in order to handle federated room.
-        if let firstRoomAlias = roomPreviewData.roomAliases?.first {
+        if let canonicalAlias = roomPreviewData.roomCanonicalAlias {
+            roomIdOrAlias = canonicalAlias
+        } else if let firstRoomAlias = roomPreviewData.roomAliases?.first {
             roomIdOrAlias = firstRoomAlias
         } else {
             roomIdOrAlias = roomPreviewData.roomId


### PR DESCRIPTION
Use the canonical alias instead of the deprecated aliases array to join a public room