### PR TITLE
[Room access] Improve the wording related to the room link access

### DIFF
--- a/TCHAP_CHANGES.rst
+++ b/TCHAP_CHANGES.rst
@@ -5,6 +5,7 @@ Features/Improvements:
  * Private rooms: turn on the option to join on room’s link #293
  * Room preview: we have to support the preview on shared room link #323
  * [Room creation] Do not override the power levels anymore #326
+ * [Room access] Improve the wordings related to the room link access #335
 
 Bug Fixes:
  * 

--- a/Tchap/Assets/Localizations/fr.lproj/Tchap.strings
+++ b/Tchap/Assets/Localizations/fr.lproj/Tchap.strings
@@ -199,6 +199,7 @@
 "room_settings_enable_room_access_by_link" = "Activer l’accès au salon par lien";
 "room_settings_enable_room_access_by_link_info_off" = "Les autres utilisateurs seront autorisés à rejoindre ce salon à partir d’un lien";
 "room_settings_enable_room_access_by_link_info_on" = "Les autres utilisateurs peuvent rejoindre ce salon à partir du lien suivant\U00A0:";
+"room_settings_enable_room_access_by_link_info_on_with_limitation" = "Les autres utilisateurs peuvent rejoindre ce salon à partir du lien suivant (une invitation reste nécessaire pour les externes)\U00A0:";
 "room_settings_room_access_by_link_share" = "Partager le lien";
 "room_settings_room_access_by_link_forbidden" = "Ce changement n’est pas supporté actuellement car les externes sont autorisés à rejoindre ce salon. Il sera supporté prochainement";
 "room_settings_allow_external_users_forbidden" = "Ce changement n’est pas supporté actuellement car le salon est accessible par lien. Il sera supporté prochainement";

--- a/Tchap/Generated/Strings.swift
+++ b/Tchap/Generated/Strings.swift
@@ -314,6 +314,8 @@ internal enum TchapL10n {
   internal static let roomSettingsEnableRoomAccessByLinkInfoOff = TchapL10n.tr("Tchap", "room_settings_enable_room_access_by_link_info_off")
   /// Les autres utilisateurs peuvent rejoindre ce salon à partir du lien suivant :
   internal static let roomSettingsEnableRoomAccessByLinkInfoOn = TchapL10n.tr("Tchap", "room_settings_enable_room_access_by_link_info_on")
+  /// Les autres utilisateurs peuvent rejoindre ce salon à partir du lien suivant (une invitation reste nécessaire pour les externes) :
+  internal static let roomSettingsEnableRoomAccessByLinkInfoOnWithLimitation = TchapL10n.tr("Tchap", "room_settings_enable_room_access_by_link_info_on_with_limitation")
   /// Échec de mise à jour de la durée de l'historique
   internal static let roomSettingsFailToUpdateRetentionPeriod = TchapL10n.tr("Tchap", "room_settings_fail_to_update_retention_period")
   /// Quitter ce salon

--- a/Tchap/Modules/Room/RoomAccessByLink/RoomAccessByLinkViewController.swift
+++ b/Tchap/Modules/Room/RoomAccessByLink/RoomAccessByLinkViewController.swift
@@ -115,8 +115,8 @@ final class RoomAccessByLinkViewController: UIViewController {
         switch viewState {
         case .loading:
             self.renderLoading()
-        case .enabled(let roomLink, let editable):
-            self.renderEnabled(roomLink: roomLink, isEditable: editable)
+        case .enabled(let roomLink, let editable, let isUnrestrictedRoom):
+            self.renderEnabled(roomLink: roomLink, isEditable: editable, isUnrestrictedRoom: isUnrestrictedRoom)
         case .disabled(let editable):
             self.renderDisabled(isEditable: editable)
         case .error(let error):
@@ -128,7 +128,7 @@ final class RoomAccessByLinkViewController: UIViewController {
         self.activityPresenter.presentActivityIndicator(on: self.view, animated: true)
     }
     
-    private func renderEnabled(roomLink: String, isEditable: Bool) {
+    private func renderEnabled(roomLink: String, isEditable: Bool, isUnrestrictedRoom: Bool) {
         self.activityPresenter.removeCurrentActivityIndicator(animated: true)
         
         roomAccessByLinkStatusLabel.isHidden = false
@@ -142,7 +142,11 @@ final class RoomAccessByLinkViewController: UIViewController {
         }
         
         roomLinkInfoLabel.isHidden = false
-        roomLinkInfoLabel.text = TchapL10n.roomSettingsEnableRoomAccessByLinkInfoOn
+        if isUnrestrictedRoom {
+            roomLinkInfoLabel.text = TchapL10n.roomSettingsEnableRoomAccessByLinkInfoOnWithLimitation
+        } else {
+            roomLinkInfoLabel.text = TchapL10n.roomSettingsEnableRoomAccessByLinkInfoOn
+        }
         roomLinkBackgroundView.isHidden = false
         roomLinkLabel.text = roomLink
         shareLinkButton.isHidden = false

--- a/Tchap/Modules/Room/RoomAccessByLink/RoomAccessByLinkViewState.swift
+++ b/Tchap/Modules/Room/RoomAccessByLink/RoomAccessByLinkViewState.swift
@@ -19,7 +19,7 @@ import Foundation
 /// RoomAccessByLinkViewController view state
 enum RoomAccessByLinkViewState {
     case loading
-    case enabled(roomLink: String, editable: Bool)
+    case enabled(roomLink: String, editable: Bool, isUnrestrictedRoom: Bool)
     case disabled(editable: Bool)
     case error(Error)
 }


### PR DESCRIPTION
In case of a private room opened to the external users, we have to notify the admins when they turn on the access by link that the external users will still require an invite to join.

#329 