### PR TITLE
Fix unexpected 404 errors

### DIFF
--- a/Tchap/Modules/Rooms/DataSources/RoomsDataSource.m
+++ b/Tchap/Modules/Rooms/DataSources/RoomsDataSource.m
@@ -102,16 +102,20 @@
 
 - (void)registerKeyBackupStateDidChangeNotification
 {
+#ifdef SUPPORT_KEYS_BACKUP
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyBackupStateDidChangeNotification:) name:kMXKeyBackupDidStateChangeNotification object:nil];
     [self keyBackupStateDidChangeNotification:nil];
     
     // Check homeserver update in background
     [self.mxSession.crypto.backup forceRefresh:nil failure:nil];
+#endif
 }
 
 - (void)unregisterKeyBackupStateDidChangeNotification
 {
+#ifdef SUPPORT_KEYS_BACKUP
     [[NSNotificationCenter defaultCenter] removeObserver:self name:kMXKeyBackupDidStateChangeNotification object:nil];
+#endif
 }
 
 - (void)keyBackupStateDidChangeNotification:(NSNotification*)notification


### PR DESCRIPTION
1 - Prevent Tchap-iOS from checking the potential key backup version each time the rooms list is displayed,
when the KeyBackup is disabled.
-> remove most of the "r0/room_keys/version" calls